### PR TITLE
pme: init: fix nfc after caf merge

### DIFF
--- a/rootdir/etc/init.target.rc
+++ b/rootdir/etc/init.target.rc
@@ -301,6 +301,10 @@ on boot
     chown system system /sys/android_cap/glove_setting
 
 on post-fs-data
+    # NFC
+    chmod 0666 /dev/pn544
+    chown nfc nfc /dev/pn544
+
     # Add a cpuset for the camera daemon
     # We want all cores for camera
     mkdir /dev/cpuset/camera-daemon


### PR DESCRIPTION
My bad, just removed this one, where merged the latest CAF tree for init section.